### PR TITLE
Add option for specifying a callback function with context

### DIFF
--- a/examples/ThreeTimers/ThreeTimers.ino
+++ b/examples/ThreeTimers/ThreeTimers.ino
@@ -1,10 +1,11 @@
 /*
-TimerEvent 0.5.0 For Arduino by cygig
+TimerEventEx 0.5.1 For Arduino by lcramos05
+TimerEventEx is based on TimerEvent from cygig.
 TimerEvent is based on TimedAction 1.6 by Alexander Brevig (alexanderbrevig@gmail.com).
 It is updated to work with Arduino IDE 1.8.5.
 
-TimerEvent provides an easy way to trigger functions every set time and is a non-blocking alternative
-to delay() function.
+TimerEventEx provides an easy way to trigger functions every set time and is a non-blocking alternative
+to delay() function. It additionally provides a way of calling the callback function passing a context pointer.
 
 */
 
@@ -13,16 +14,16 @@ to delay() function.
 // The second prints a flips a boolean between 1 and 0 every 1361ms.
 // The third prints the time that the sketch has been running every 3000ms.
 
-#include <TimerEvent.h>
+#include <TimerEventEx.h>
 
 const unsigned int timerOnePeriod = 997;
 const unsigned int timerTwoPeriod = 1361;
 const unsigned int timerThreePeriod = 3000;
 
-// Create two TimerEvent instances
-TimerEvent timerOne;
-TimerEvent timerTwo;
-TimerEvent timerThree;
+// Create two TimerEventEx instances
+TimerEventEx timerOne;
+TimerEventEx timerTwo;
+TimerEventEx timerThree;
 
 bool myBool=false;
 

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=TimerEvent
-version=0.5.0
-author=cygig <rubbish52@hotmail.com>
-maintainer=cygig <rubbish52@hotmail.com>
-sentence=TimerEvent is a non-blocking alternative to the delay() function. 
-paragraph=It provides an easy way to trigger a callback function every set period of time and using multiple instances of this library enables your Arduino to multitask via time slicing.
+version=0.5.1
+author=Luiz Ramos <lramos.prof@yahoo.com.br>
+maintainer=Luiz Ramos <lramos.prof@yahoo.com.br>
+sentence=TimerEventEx is a non-blocking alternative to the delay() function. 
+paragraph=It provides an easy way to trigger a callback function every set period of time and using multiple instances of this library enables your Arduino to multitask via time slicing. Credits to cygig (original author of TimerEvent)
 category=Timing
-url=https://github.com/cygig/TimerEvent
+url=https://github.com/lcramos05/TimerEventEx
 architectures=*

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
-# TimerEvent
-TimerEvent is a non-blocking alternative to the delay() function. It provides an easy way to trigger a callback function every set period of time and using multiple instances of this library enables your Arduino to multitask via time slicing.
+# TimerEventEx
+TimerEventEx is a non-blocking alternative to the delay() function. It provides an easy way to trigger a callback function every set period of time and using multiple instances of this library enables your Arduino to multitask via time slicing.
+
+TimerEventEx is based on TimerEvent from cygig. The difference is that TimerEventEx provides a way of passing a context pointer to the callback function.
 
 TimerEvent is based on TimedAction 1.6 by Alexander Brevig (alexanderbrevig@gmail.com). It is updated to work with Arduino IDE 1.8.5 and above.
 

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,9 @@ TimerEvent is a non-blocking alternative to the delay() function. It provides an
 TimerEvent is based on TimedAction 1.6 by Alexander Brevig (alexanderbrevig@gmail.com). It is updated to work with Arduino IDE 1.8.5 and above.
 
 # Updates
+- 0.5.1
+ 	- Forked from cygig/TimerEvent and subsequently renamed to TimerEventEx
+	- Included new methods to allow calling callbacks passing a context pointer
 - 0.5.0
 	- Changed period of timer from `unsigned long` to `unsigned int` as most timer update less than every few seconds to save RAM. You can change `periodInInt ` definition in header file to `0` to set it back to `unsigned long`.
 	- Added isEnabled() to check if the timer is enabled.

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,12 @@ For example: myTimer.set(1000, myFunction);
 ## _void_ set(_unsigned long_ myLastTime, _unsigned long_ myPeriod, _void_ (*myFunction)())
 Similar to the other `set` function, but you can set the last callback time in milliseconds. The library will compare the last callback time against the current time to know if the callback function should be called. It will also update this last callback time after every callback. `myLastTime` is the last callback time in `unsigned long`, which will otherwise be set to the current time if not declared.
 
+## _void_ set(_unsigned long_ myPeriod, _void_ (*myFunction)(_const TimerEvent_ *, _void_ *), _void_ *myContext)
+Similar to the first simpler `set` function, but one can additionally provide an opaque pointer to be used when the callback function is called. This can help in cases where a couple of similar timers are used (like e.g. an array of timers) and there should be a way of telling a single callback function which context the timer relates to.
+
+## _void_ set(_unsigned long_ myLastTime, _unsigned long_ myPeriod, _void_ (*myFunction)(_const TimerEvent_ *, _void_ *), _void_ *myContext)
+Similar to the second `set` function, but one can additionally provide an opaque pointer to be used when the callback function is called. This can help in cases where a couple of similar timers are used (like e.g. an array of timers) and there should be a way of telling a single callback function which context the timer relates to.
+
 ## _void_ reset()
 Resets the timer.
 

--- a/src/TimerEvent.cpp
+++ b/src/TimerEvent.cpp
@@ -14,7 +14,21 @@ void TimerEvent::set(unsigned long myLastTime,unsigned long myPeriod,void (*myFu
 	period = myPeriod;
 	lastTime = myLastTime;
 	callBackFunction = myFunction;	
-	
+	richCallBackFunction = nullptr;
+	context = nullptr;
+}
+
+void TimerEvent::set(unsigned long myPeriod,void (*myFunction)(const TimerEvent*, void*),void* myContext) {
+    set(millis(), myPeriod, myFunction, myContext);	
+}
+
+void TimerEvent::set(unsigned long myLastTime,unsigned long myPeriod,void (*myFunction)(const TimerEvent*, void*),void* myContext) {
+    enabled = true;
+    period = myPeriod;
+    lastTime = myLastTime;
+    callBackFunction = nullptr;
+    richCallBackFunction = myFunction;
+    context = myContext;
 }
 
 void TimerEvent::reset(){
@@ -31,8 +45,12 @@ void TimerEvent::enable(){
 
 void TimerEvent::update(){
   if ( enabled && ((unsigned long) (millis()-lastTime) >= period) ) {
-    callBackFunction();
-	  lastTime = millis();
+    if (callBackFunction) {
+      callBackFunction();
+    } else if (richCallBackFunction) {
+      richCallBackFunction(this, context);
+    }
+    lastTime = millis();
   }
 }
 

--- a/src/TimerEvent.h
+++ b/src/TimerEvent.h
@@ -31,6 +31,8 @@ class TimerEvent {
     TimerEvent();
   	void set(unsigned long myPeriod,void (*myFunction)());
   	void set(unsigned long myTimer,unsigned long myPeriod,void (*myFunction)());
+  	void set(unsigned long myPeriod,void (*myFunction)(const TimerEvent*, void*), void* myContext);
+  	void set(unsigned long myTimer,unsigned long myPeriod,void (*myFunction)(const TimerEvent*, void*), void* myContext);
   	void reset();
   	void disable();
   	void enable();
@@ -47,6 +49,8 @@ class TimerEvent {
       unsigned long period;
     #endif
     void (*callBackFunction)();
+    void (*richCallBackFunction)(const TimerEvent*, void*);
+    void* context;
 		
 };
 

--- a/src/TimerEventEx.cpp
+++ b/src/TimerEventEx.cpp
@@ -1,15 +1,15 @@
-#include "TimerEvent.h"
+#include "TimerEventEx.h"
 
-TimerEvent::TimerEvent(){
+TimerEventEx::TimerEventEx(){
 // Nothing inside constructor.
 // We use set instead if not we need to declare myFunction on top of setup().
 }
 
-void TimerEvent::set(unsigned long myPeriod,void (*myFunction)()){
+void TimerEventEx::set(unsigned long myPeriod,void (*myFunction)()){
   set(millis(), myPeriod, myFunction);	
 }
 
-void TimerEvent::set(unsigned long myLastTime,unsigned long myPeriod,void (*myFunction)()){
+void TimerEventEx::set(unsigned long myLastTime,unsigned long myPeriod,void (*myFunction)()){
   enabled = true;
 	period = myPeriod;
 	lastTime = myLastTime;
@@ -18,11 +18,11 @@ void TimerEvent::set(unsigned long myLastTime,unsigned long myPeriod,void (*myFu
 	context = nullptr;
 }
 
-void TimerEvent::set(unsigned long myPeriod,void (*myFunction)(const TimerEvent*, void*),void* myContext) {
+void TimerEventEx::set(unsigned long myPeriod,void (*myFunction)(const TimerEventEx*, void*),void* myContext) {
     set(millis(), myPeriod, myFunction, myContext);	
 }
 
-void TimerEvent::set(unsigned long myLastTime,unsigned long myPeriod,void (*myFunction)(const TimerEvent*, void*),void* myContext) {
+void TimerEventEx::set(unsigned long myLastTime,unsigned long myPeriod,void (*myFunction)(const TimerEventEx*, void*),void* myContext) {
     enabled = true;
     period = myPeriod;
     lastTime = myLastTime;
@@ -31,19 +31,19 @@ void TimerEvent::set(unsigned long myLastTime,unsigned long myPeriod,void (*myFu
     context = myContext;
 }
 
-void TimerEvent::reset(){
+void TimerEventEx::reset(){
     lastTime = millis();
 }
 
-void TimerEvent::disable(){
+void TimerEventEx::disable(){
     enabled = false;
 }
 
-void TimerEvent::enable(){
+void TimerEventEx::enable(){
 	enabled = true;
 }
 
-void TimerEvent::update(){
+void TimerEventEx::update(){
   if ( enabled && ((unsigned long) (millis()-lastTime) >= period) ) {
     if (callBackFunction) {
       callBackFunction();
@@ -54,10 +54,10 @@ void TimerEvent::update(){
   }
 }
 
-void TimerEvent::setPeriod( unsigned long myPeriod){
+void TimerEventEx::setPeriod( unsigned long myPeriod){
 	period = myPeriod;
 }
 
-bool TimerEvent::isEnabled(){
+bool TimerEventEx::isEnabled(){
   return enabled;
 }

--- a/src/TimerEventEx.h
+++ b/src/TimerEventEx.h
@@ -1,10 +1,11 @@
 /*
-TimerEvent 0.4.0 For Arduino by cygig
+TimerEventEx 0.5.1 For Arduino by lcramos05
+TimerEventEx is based on TimerEvent from cygig.
 TimerEvent is based on TimedAction 1.6 by Alexander Brevig (alexanderbrevig@gmail.com).
 It is updated to work with Arduino IDE 1.8.5.
 
-TimerEvent provides an easy way to trigger functions every set time and is a non-blocking alternative
-to delay() function.
+TimerEventEx provides an easy way to trigger functions every set time and is a non-blocking alternative
+to delay() function. It also provides a way of calling the callback function passing a context pointer.
 
 */
 
@@ -25,10 +26,10 @@ to delay() function.
 #define periodInInt 1
 
 
-class TimerEvent {
+class TimerEventEx {
   
   public:
-    TimerEvent();
+    TimerEventEx();
   	void set(unsigned long myPeriod,void (*myFunction)());
   	void set(unsigned long myTimer,unsigned long myPeriod,void (*myFunction)());
   	void set(unsigned long myPeriod,void (*myFunction)(const TimerEvent*, void*), void* myContext);
@@ -49,7 +50,7 @@ class TimerEvent {
       unsigned long period;
     #endif
     void (*callBackFunction)();
-    void (*richCallBackFunction)(const TimerEvent*, void*);
+    void (*richCallBackFunction)(const TimerEventEx*, void*);
     void* context;
 		
 };


### PR DESCRIPTION
This is an improvement to the library.

It allows users to use similar timers with a single, shared callback function. This function has in its prototype two parameters, instead of zero as the legacy callback: one for the timer pointer and another for a opaque pointer (which could be an user defined context ptr) which is provided when calling `set()`.

This can be useful when using for instance an array of timers to do similar jobs (like in my case, where I'd like to manage making a number of LEDs to switch off after a fixed period of time).

For this reason there are two other versions of `set()`, which allow passing that opaque pointer.

The update was done in a way that doesn't break compatibility with legacy users so there should be no compatibility issues.